### PR TITLE
Trivial refactoring after version upgrade

### DIFF
--- a/client/src/main/java/com/sastix/cms/client/impl/CmsClient.java
+++ b/client/src/main/java/com/sastix/cms/client/impl/CmsClient.java
@@ -21,9 +21,6 @@ import com.sastix.cms.client.CacheClient;
 import com.sastix.cms.client.ContentClient;
 import com.sastix.cms.client.LockClient;
 import com.sastix.cms.common.Constants;
-import com.sastix.cms.common.api.CacheApi;
-import com.sastix.cms.common.api.ContentApi;
-import com.sastix.cms.common.api.LockApi;
 import com.sastix.cms.common.cache.CacheDTO;
 import com.sastix.cms.common.cache.QueryCacheDTO;
 import com.sastix.cms.common.cache.RemoveCacheDTO;
@@ -45,6 +42,8 @@ import com.sastix.cms.common.lock.exceptions.LockNotAllowed;
 import com.sastix.cms.common.lock.exceptions.LockNotFound;
 import com.sastix.cms.common.lock.exceptions.LockNotHeld;
 import com.sastix.cms.common.lock.exceptions.LockValidationException;
+
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -57,7 +56,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/common/api/src/main/java/com/sastix/cms/common/api/CacheApi.java
+++ b/common/api/src/main/java/com/sastix/cms/common/api/CacheApi.java
@@ -23,7 +23,6 @@ import com.sastix.cms.common.cache.exceptions.CacheValidationException;
 import com.sastix.cms.common.cache.exceptions.DataNotFound;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.util.List;
 
 public interface CacheApi {

--- a/common/api/src/main/java/com/sastix/cms/common/api/ContentApi.java
+++ b/common/api/src/main/java/com/sastix/cms/common/api/ContentApi.java
@@ -16,30 +16,13 @@
 
 package com.sastix.cms.common.api;
 
-import com.sastix.cms.common.cache.CacheDTO;
-import com.sastix.cms.common.cache.QueryCacheDTO;
-import com.sastix.cms.common.cache.RemoveCacheDTO;
-import com.sastix.cms.common.cache.exceptions.CacheValidationException;
-import com.sastix.cms.common.cache.exceptions.DataNotFound;
 import com.sastix.cms.common.content.*;
 import com.sastix.cms.common.content.exceptions.ContentValidationException;
 import com.sastix.cms.common.content.exceptions.ResourceAccessError;
 import com.sastix.cms.common.content.exceptions.ResourceNotFound;
 import com.sastix.cms.common.content.exceptions.ResourceNotOwned;
-import com.sastix.cms.common.dataobjects.ResponseDTO;
-import com.sastix.cms.common.dataobjects.VersionDTO;
-import com.sastix.cms.common.lock.LockDTO;
-import com.sastix.cms.common.lock.NewLockDTO;
-import com.sastix.cms.common.lock.QueryLockDTO;
-import com.sastix.cms.common.lock.exceptions.LockNotAllowed;
-import com.sastix.cms.common.lock.exceptions.LockNotFound;
-import com.sastix.cms.common.lock.exceptions.LockNotHeld;
-import com.sastix.cms.common.lock.exceptions.LockValidationException;
 
 import java.io.IOException;
-import java.net.URL;
-import java.util.List;
-import java.util.Map;
 
 public interface ContentApi {
 

--- a/common/client/src/main/java/com/sastix/cms/common/client/CmsRetryPolicy.java
+++ b/common/client/src/main/java/com/sastix/cms/common/client/CmsRetryPolicy.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 public class CmsRetryPolicy extends SimpleRetryPolicy {
 
+    private static final long serialVersionUID = 1L;
 
     private BinaryExceptionClassifier businessExceptionClassifier = new BinaryExceptionClassifier(false);
 

--- a/common/services/src/main/java/com/sastix/cms/common/services/htmltopdf/PdfBuilder.java
+++ b/common/services/src/main/java/com/sastix/cms/common/services/htmltopdf/PdfBuilder.java
@@ -17,14 +17,11 @@
 package com.sastix.cms.common.services.htmltopdf;
 
 import com.sastix.cms.common.services.htmltopdf.config.HtmlToPdfConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class PdfBuilder {
-    private static final Logger LOG = LoggerFactory.getLogger(PdfBuilder.class);
 
     @Autowired
     HtmlToPdfConfig htmlToPdfConfig;

--- a/server/src/main/java/com/sastix/cms/server/controllers/CacheController.java
+++ b/server/src/main/java/com/sastix/cms/server/controllers/CacheController.java
@@ -47,7 +47,6 @@ import java.util.List;
 @RestController
 @Lazy
 @RequestMapping("/" + CmsServer.CONTEXT)
-@SuppressWarnings("unchecked")
 public class CacheController implements BeanFactoryAware {
 
     /**

--- a/server/src/main/java/com/sastix/cms/server/services/cache/CacheService.java
+++ b/server/src/main/java/com/sastix/cms/server/services/cache/CacheService.java
@@ -17,13 +17,6 @@
 package com.sastix.cms.server.services.cache;
 
 import com.sastix.cms.common.api.CacheApi;
-import com.sastix.cms.common.cache.CacheDTO;
-import com.sastix.cms.common.cache.QueryCacheDTO;
-import com.sastix.cms.common.cache.RemoveCacheDTO;
-import com.sastix.cms.common.cache.exceptions.CacheValidationException;
-import com.sastix.cms.common.cache.exceptions.DataNotFound;
-import java.io.IOException;
-import java.util.List;
 
 /**
  * Distributed Cache interface.

--- a/server/src/main/java/com/sastix/cms/server/services/cache/hazelcast/HazelcastCacheService.java
+++ b/server/src/main/java/com/sastix/cms/server/services/cache/hazelcast/HazelcastCacheService.java
@@ -27,6 +27,8 @@ import com.sastix.cms.common.cache.exceptions.DataNotFound;
 import com.sastix.cms.server.services.cache.CacheFileUtilsService;
 import com.sastix.cms.server.services.cache.CacheService;
 import com.sastix.cms.server.services.cache.manager.DistributedCacheManager;
+
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -37,7 +39,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.net.URL;
@@ -91,7 +92,7 @@ public class HazelcastCacheService implements CacheService, BeanFactoryAware {
         byte[] blob;
         String blobURI = cacheDTO.getCacheBlobURI();
 
-        if(!StringUtils.isEmpty(blobURI) && !StringUtils.isEmpty(cacheDTO.getCacheBlobBinary())){
+        if(!StringUtils.isEmpty(blobURI) && cacheDTO.getCacheBlobBinary().length > 0){
             throw new CacheValidationException("Client should NOT be able to send both blob AND URI. Only one of them");
         }
 

--- a/server/src/main/java/com/sastix/cms/server/services/content/impl/CommonResourceServiceImpl.java
+++ b/server/src/main/java/com/sastix/cms/server/services/content/impl/CommonResourceServiceImpl.java
@@ -26,12 +26,13 @@ import com.sastix.cms.server.domain.repositories.ResourceRepository;
 import com.sastix.cms.server.domain.repositories.RevisionRepository;
 import com.sastix.cms.server.services.content.HashedDirectoryService;
 import com.sastix.cms.server.services.content.ZipFileHandlerService;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tika.Tika;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.util.*;
@@ -145,10 +146,8 @@ public class CommonResourceServiceImpl {
 
     public AnalyzedZipResource analyzeZipFile(String context, String resourceURI, Resource zipResource) {
         byte[] insertedBytes;
-        DataMaps modifiedDataMaps = null;
         List<ResourceDTO> resourceDTOList = new ArrayList<>();
         String startPage = null;
-        String scormLandingPage = null;
         Resource parentResource = null;
         boolean isScormType=false;
         boolean isResourceWithStartPage = false;

--- a/server/src/main/java/com/sastix/cms/server/services/content/impl/hazelcast/HazelcastResourceServiceImpl.java
+++ b/server/src/main/java/com/sastix/cms/server/services/content/impl/hazelcast/HazelcastResourceServiceImpl.java
@@ -265,7 +265,7 @@ public class HazelcastResourceServiceImpl implements ResourceService {
             archivedResource.setPath(relativePath);
             archivedResource.setUid(UID);
             //insert archived entry
-            Resource insertedArchivedResource = resourceRepository.save(archivedResource);
+            resourceRepository.save(archivedResource);
 
 
             /**

--- a/server/src/main/java/com/sastix/cms/server/services/content/impl/singlenode/SingleResourceServiceImpl.java
+++ b/server/src/main/java/com/sastix/cms/server/services/content/impl/singlenode/SingleResourceServiceImpl.java
@@ -32,8 +32,6 @@ import com.sastix.cms.server.services.content.impl.CommonResourceServiceImpl;
 import com.sastix.cms.server.utils.MultipartFileSender;
 import org.apache.tika.Tika;
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.InputStreamResource;
@@ -51,7 +49,6 @@ import java.util.concurrent.ConcurrentHashMap;
 @Service
 @Profile("single")
 public class SingleResourceServiceImpl implements ResourceService {
-    private Logger LOG = (Logger) LoggerFactory.getLogger(SingleResourceServiceImpl.class);
 
     @Autowired
     ResourceRepository resourceRepository;
@@ -269,7 +266,7 @@ public class SingleResourceServiceImpl implements ResourceService {
             archivedResource.setPath(relativePath);
             archivedResource.setUid(UID);
             //insert archived entry
-            Resource insertedArchivedResource = resourceRepository.save(archivedResource);
+            resourceRepository.save(archivedResource);
 
 
             /**

--- a/server/src/main/java/com/sastix/cms/server/services/lock/LockService.java
+++ b/server/src/main/java/com/sastix/cms/server/services/lock/LockService.java
@@ -17,13 +17,6 @@
 package com.sastix.cms.server.services.lock;
 
 import com.sastix.cms.common.api.LockApi;
-import com.sastix.cms.common.lock.LockDTO;
-import com.sastix.cms.common.lock.NewLockDTO;
-import com.sastix.cms.common.lock.QueryLockDTO;
-import com.sastix.cms.common.lock.exceptions.LockNotAllowed;
-import com.sastix.cms.common.lock.exceptions.LockNotFound;
-import com.sastix.cms.common.lock.exceptions.LockNotHeld;
-import com.sastix.cms.common.lock.exceptions.LockValidationException;
 
 /**
  * Distributed Lock interface.

--- a/server/src/main/java/com/sastix/cms/server/services/lock/hazelcast/HazelcastLockService.java
+++ b/server/src/main/java/com/sastix/cms/server/services/lock/hazelcast/HazelcastLockService.java
@@ -167,6 +167,7 @@ public class HazelcastLockService implements LockService,BeanFactoryAware {
         }
 
         if(savedLockedDTO == null){
+            //TODO: this is dead code
             throw new LockNotHeld("The lock is not held anymore.This is not expected..");
         }
 

--- a/server/src/main/java/com/sastix/cms/server/utils/FileService.java
+++ b/server/src/main/java/com/sastix/cms/server/utils/FileService.java
@@ -16,9 +16,9 @@
 
 package com.sastix.cms.server.utils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 import java.io.*;
 import java.net.MalformedURLException;

--- a/server/src/test/java/com/sastix/cms/server/config/CmsConfiguration.java
+++ b/server/src/test/java/com/sastix/cms/server/config/CmsConfiguration.java
@@ -16,9 +16,6 @@
 
 package com.sastix.cms.server.config;
 
-import com.sastix.cms.server.services.cache.CacheService;
-import com.sastix.cms.server.services.cache.hazelcast.HazelcastCacheService;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 

--- a/server/src/test/java/com/sastix/cms/server/services/cache/CacheFileUtilsServiceTest.java
+++ b/server/src/test/java/com/sastix/cms/server/services/cache/CacheFileUtilsServiceTest.java
@@ -17,9 +17,6 @@
 package com.sastix.cms.server.services.cache;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -35,7 +32,6 @@ import java.util.Arrays;
 @ActiveProfiles({"production", "test"})
 @ContextConfiguration(classes = CacheFileUtilsServiceImpl.class)
 public class CacheFileUtilsServiceTest {
-    private static final Logger LOG = LoggerFactory.getLogger(CacheFileUtilsServiceTest.class);
 
     CacheFileUtilsService cacheFileUtilsService = new CacheFileUtilsServiceImpl();
 

--- a/server/src/test/java/com/sastix/cms/server/services/cache/CacheServiceTest.java
+++ b/server/src/test/java/com/sastix/cms/server/services/cache/CacheServiceTest.java
@@ -26,8 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -43,7 +41,6 @@ import static org.junit.jupiter.api.Assertions.*;
 @ActiveProfiles({"production", "test"})
 @SpringBootTest(classes = {CmsServer.class})
 public class CacheServiceTest {
-    private Logger LOG = LoggerFactory.getLogger(CacheServiceTest.class);
 
     @Autowired
     private CacheService cacheService;

--- a/server/src/test/java/com/sastix/cms/server/services/content/ResourceServiceTest.java
+++ b/server/src/test/java/com/sastix/cms/server/services/content/ResourceServiceTest.java
@@ -21,7 +21,6 @@ import com.sastix.cms.common.content.exceptions.ContentValidationException;
 import com.sastix.cms.common.content.exceptions.ResourceAccessError;
 import com.sastix.cms.common.content.exceptions.ResourceNotFound;
 import com.sastix.cms.server.CmsServer;
-import com.sastix.cms.server.services.content.impl.HashedDirectoryServiceImpl;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -162,9 +161,4 @@ public class ResourceServiceTest {
         }
     }
 
-    private String getAbsolutePath(final String temporaryFolderPath, final String relativePath) {
-        final Path volumeIdentifier = Paths.get(HashedDirectoryServiceImpl.VOLUME_IDENTIFIER);
-        final Path relative = Paths.get(relativePath);
-        return new StringBuilder().append(temporaryFolderPath).append("/").append("/").append(volumeIdentifier.relativize(relative).toString()).toString();
-    }
 }

--- a/server/src/test/java/com/sastix/cms/server/services/content/ZipFileHandlerServiceTest.java
+++ b/server/src/test/java/com/sastix/cms/server/services/content/ZipFileHandlerServiceTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 


### PR DESCRIPTION
Hi,

I did some trivial changes to some of the files. The changes contain:

- removal of unused imports, variables, annotations, loggers.
- substitution of the deprecated isEmpty method StringUtils package from the spring framework with the org.apache.commons.lang3.StringUtils.
- addition of a default static final long field to serializable class.
- addition of a try-with-resources to avoid resource leak due to non-closing ServletOutputStream.

Further work may include:

- extraction of the nullvalidationchecker method to a mixin.
- some type safety issues (e.g. IMap)
- refactoring of the dead code in HazelcastLockService.java (I wasn't sure if the inclusion of the throw in the above code was desirable)